### PR TITLE
fixbug:change the logic of NoneOf in auth::Right::evaluate

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -92,7 +92,7 @@ impl Rights {
 
                 all
             }
-            Self::NoneOf(rights) => !{
+            Self::NoneOf(rights) => {
                 let mut all = true;
                 for r in rights.iter() {
                     if r.evaluate(user, db).await {


### PR DESCRIPTION
Backgroud:
- I found the function of Rights::none  is  the same as  Right::any  when  I run the demo in README.

Cause:
- An extra  “ ! ” leads to the logic error 

I think the work of noneof is cheking based on  "every Rights in noneof must be false".
to be honest, I think the noneof is useless. because  it eq !anyof